### PR TITLE
Move initilization of global memory to the init handler.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 .vscode
 .idea
-.iml
-.balx
-.ballerina
+*.iml
+*.balx
 *~
 
+.ballerina
 ballerina-internal.log
 
 .gradle/

--- a/ballerina/.dockerignore
+++ b/ballerina/.dockerignore
@@ -1,0 +1,3 @@
+*~
+proxy/build
+proxy/out

--- a/ballerina/proxy/src/main/java/org/ballerinalang/openwhisk/runtime/Constants.java
+++ b/ballerina/proxy/src/main/java/org/ballerinalang/openwhisk/runtime/Constants.java
@@ -34,14 +34,14 @@ class Constants {
     static final String RESPONSE_ERROR = "\"error\"";
     static final String RESPONSE_SUCCESS = "\"success\"";
 
-    static final String INIT_SUCCESS = "\"Function init success\"";
+    static final String INIT_SUCCESS = "\"Function initialized successfully.\"";
 
     static final String INIT_ONCE_ERROR = "\"Cannot initialize the action more than once.\"";
     static final String FAILED_TO_LOCATE_BINARY =
             "\"The action failed to generate or locate a binary. See logs for details.\"";
     static final String MISSING_MAIN_ERROR = "\"Missing main/no code to " + "execute.\"";
-    static final String FUNCTION_NOT_INITIALIZED = "\"Function not initialized\"";
-    static final String INVALID_INPUT_PARAMS = "\"Invalid input parameters for action run\"";
-    static final String FUNCTION_RUN_FAILURE = "\"Running Function failed\"";
+    static final String FUNCTION_NOT_INITIALIZED = "\"Function not initialized.\"";
+    static final String INVALID_INPUT_PARAMS = "\"Invalid input parameters for action run.\"";
+    static final String FUNCTION_RUN_FAILURE = "\"Function failed while running.\"";
     static final String DICTIONARY_RETURN_FAILURE = "\"The action did not return a dictionary.\"";
 }

--- a/tests/src/test/resources/hello/hello.bal
+++ b/tests/src/test/resources/hello/hello.bal
@@ -5,7 +5,6 @@ function main(string... args) {
 }
 
 function run(json jsonInput) returns json {
-   io:println(jsonInput);
-   json output = { "response": "hello-world"};
+   json output = { "response": "hello-world" };
    return output;
 }

--- a/tests/src/test/scala/actionContainers/BallerinaActionContainerTests.scala
+++ b/tests/src/test/scala/actionContainers/BallerinaActionContainerTests.scala
@@ -73,8 +73,6 @@ class BallerinaActionContainerTests extends BasicActionRunnerTests with WskActor
     TestConfig(buildBal("return-response"))
   }
 
-  behavior of ballerinaContainerImageName
-
   it should "Initialize with the hello code and invoke" in {
     val (out, err) = withActionContainer() { c =>
       val sourceFile = buildBal("hello")
@@ -137,9 +135,11 @@ class BallerinaActionContainerTests extends BasicActionRunnerTests with WskActor
   }
 
   def buildBal(functionName: String): String = {
-    // Set Ballerina home path to resolve dependency libs
-    val ballerinaHome = Paths.get(System.getProperty("user.dir"), "..", "ballerina", "proxy", "build")
-    System.setProperty("ballerina.home", ballerinaHome.toString)
+    // Set Ballerina home path to resolve dependency libs if necessary
+    if (System.getProperty("ballerina.home") == null) {
+      val ballerinaHome = Paths.get(System.getProperty("user.dir"), "..", "ballerina", "proxy", "build")
+      System.setProperty("ballerina.home", ballerinaHome.toString)
+    }
 
     val path = getClass.getResource("/".concat(functionName)).getPath
     val context = new CompilerContext


### PR DESCRIPTION
This change permits the persistence of a cache across hot activations.
