### PR TITLE
Update to new base image jdk8u202-b08_openj9-0.12.1.

### DIFF
--- a/ballerina/CHANGELOG.md
+++ b/ballerina/CHANGELOG.md
@@ -1,0 +1,22 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
+
+## Initial release
+
+- Added: Ballerina v0.990.2

--- a/ballerina/Dockerfile
+++ b/ballerina/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM adoptopenjdk/openjdk8-openj9:jdk8u162-b12_openj9-0.8.0
+FROM adoptopenjdk/openjdk8-openj9:jdk8u202-b08_openj9-0.12.1
 
 RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update \
 	&& apt-get install -y --no-install-recommends locales \
@@ -26,8 +26,8 @@ ENV LANG="en_US.UTF-8" \
 	LANGUAGE="en_US:en" \
 	LC_ALL="en_US.UTF-8" \
 	VERSION=8 \
-	UPDATE=162 \
-	BUILD=12
+	UPDATE=202 \
+	BUILD=08
 
 ADD proxy /home/ballerina
 RUN cd /home/ballerina \


### PR DESCRIPTION
- Update to a new base image with security fixes and some updates.